### PR TITLE
Better error handling when no target files

### DIFF
--- a/src/main/java/com/zamzar/api/ImportsService.java
+++ b/src/main/java/com/zamzar/api/ImportsService.java
@@ -50,14 +50,14 @@ public class ImportsService implements Listable<ImportManager, Integer> {
      * Starts an import request.
      */
     public ImportManager start(String url) throws ApiException {
-        return new ImportManager(zamzar, api.startImport(url, null));
+        return toImport(api.startImport(url, null));
     }
 
     /**
      * Starts an import request, overriding the filename (rather than using the filename from the URL).
      */
     public ImportManager start(String url, String filename) throws ApiException {
-        return new ImportManager(zamzar, api.startImport(url, filename));
+        return toImport(api.startImport(url, filename));
     }
 
     protected List<ImportManager> toImports(List<ModelImport> models) {

--- a/src/main/java/com/zamzar/api/JobManager.java
+++ b/src/main/java/com/zamzar/api/JobManager.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -68,6 +69,10 @@ public class JobManager extends Awaitable<JobManager> {
      * Returns the IDs of the target files produced by the conversion.
      */
     public List<Integer> getTargetFileIds() {
+        if (getTargetFiles() == null) {
+            return Collections.emptyList();
+        }
+
         return getTargetFiles()
             .stream()
             .mapToInt(ModelFile::getId)

--- a/src/test/java/com/zamzar/api/JobBuilderTest.java
+++ b/src/test/java/com/zamzar/api/JobBuilderTest.java
@@ -47,11 +47,11 @@ public class JobBuilderTest {
         return Stream.of(
             // URL / extension
             Arguments.of("https://example.com/file", null),
-            Arguments.of("https://example.com/file?query=param", null, "file"),
-            Arguments.of("https://example.com/", "txt", null),
-            Arguments.of("https://example.com/", null, null),
-            Arguments.of("https://example.com", "txt", null),
-            Arguments.of("https://example.com", null, null)
+            Arguments.of("https://example.com/file?query=param", null),
+            Arguments.of("https://example.com/", "txt"),
+            Arguments.of("https://example.com/", null),
+            Arguments.of("https://example.com", "txt"),
+            Arguments.of("https://example.com", null)
         );
     }
 }

--- a/src/test/java/com/zamzar/api/JobManagerTest.java
+++ b/src/test/java/com/zamzar/api/JobManagerTest.java
@@ -83,4 +83,10 @@ public class JobManagerTest extends ZamzarApiTest {
         assertEquals(3, pngs.size());
         pngs.forEach(ZamzarApiTest::assertNonEmptyFile);
     }
+
+    @Test
+    public void storeThrowsWhenNoTargetFiles() throws Exception {
+        final JobManager job = zamzar().jobs().find(FAILING_JOB_ID).await();
+        assertThrows(ApiException.class, () -> job.store(createTempFile("output").toFile()));
+    }
 }

--- a/src/test/java/com/zamzar/api/JobsServiceTest.java
+++ b/src/test/java/com/zamzar/api/JobsServiceTest.java
@@ -4,13 +4,10 @@ import com.zamzar.api.invoker.ApiException;
 import com.zamzar.api.model.Job;
 import com.zamzar.api.pagination.Anchor;
 import com.zamzar.api.pagination.Paged;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 
 import java.net.URI;
 import java.nio.file.Path;
-import java.util.List;
-import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -110,7 +107,15 @@ public class JobsServiceTest extends ZamzarApiTest {
             .jobs()
             .create(new URI("https://www.example.com/logo.png"), "jpg");
 
-        // Check that a non-empty file has been downloaded
+        assertTrue(job.getId() > 0);
+    }
+
+    @Test
+    public void createFromExistingFile() throws Exception {
+        final JobManager job = zamzar()
+            .jobs()
+            .create(FILE_ID, "jpg");
+
         assertTrue(job.getId() > 0);
     }
 
@@ -131,16 +136,5 @@ public class JobsServiceTest extends ZamzarApiTest {
 
         // Check that fresh requests return the updated status
         assertEquals(Job.StatusEnum.CANCELLED, job.refresh().getModel().getStatus());
-    }
-
-    private void createJobs(int count) throws Exception {
-        for (int i = 0; i < count; i++) {
-            zamzar().jobs().create(createTempFile("input-" + i).toFile(), "txt");
-        }
-    }
-
-    @NotNull
-    private static List<Integer> getIdsOfJobsIn(Paged<JobManager, Integer> page) {
-        return page.getItems().stream().map(JobManager::getId).collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
Ensures that we throw a more explicit exception when an attempt is made to download files for a conversion job that has no target files (e.g., has not yet completed; has failed).

Also:
* deletes a bit of dead code
* regenerates for the latest version of zamzar-spec (only affects Javadoc here)