### PR TITLE
Updates Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,5 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,9 @@ updates:
       interval: "daily"
     cooldown:
       default-days: 7
+  - package-ecosystem: "docker-compose"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
- Extends the default cooldown to 7 days (security fixes are exempt by default)
- Tracks image versions in the docker compose file so that Dependabot will bump the OpenAPI Generator CLI from now on